### PR TITLE
Fix setting haxelib version.

### DIFF
--- a/install.js
+++ b/install.js
@@ -59,7 +59,7 @@ function findPackageJson() {
 var haxeDir = vars.haxe.dir;
 var haxelibDir = vars.haxelib.dir;
 
-var haxeVersion = packageConfig('version');
+var haxeVersion = packageConfig('haxe');
 try {
 	var pack = findPackageJson();
 	if(pack != false) {
@@ -69,13 +69,16 @@ try {
 	console.warn('using default version');
 }
 if(haxeVersion == undefined){
-	haxeVersion = packageConfig('version');
+	haxeVersion = packageConfig('haxe');
 }
 
 var nightly = packageConfig('nightly');
 var haxelibVersion = packageConfig('haxelib_version');
 try {
-	haxelibVersion = parent().parse().config.haxelib;
+	var pack = findPackageJson();
+	if(pack != false) {
+		haxelibVersion = pack.parse().config.haxelib_version;
+	}
 } catch (error){
 	console.warn('using default haxelib version');
 }

--- a/lib/vars.js
+++ b/lib/vars.js
@@ -1,9 +1,18 @@
+var fs = require('fs');
 var path = require('path');
 var packagePath = require('./path');
 
 var downloadsPath = packagePath('downloads');
 var haxeDir = path.join(downloadsPath, 'haxe');
 var haxelibDir = path.join(downloadsPath, 'haxelib');
+var haxelibSrcDir = path.join(haxelibDir, 'src');
+var haxelibMain = 'UnknownHaxelibMain';
+
+if (fs.existsSync(path.join(haxelibSrcDir, 'tools', 'haxelib', 'Main.hx'))) {
+    haxelibMain = 'tools.haxelib.Main';
+} else if (fs.existsSync(path.join(haxelibSrcDir, 'haxelib', 'client', 'Main.hx'))) {
+    haxelibMain = 'haxelib.client.Main';
+}
 
 var vars = module.exports = {
     haxe : {
@@ -14,8 +23,8 @@ var vars = module.exports = {
         dir: haxelibDir,
         path: path.join(haxeDir, 'haxe'),
         args: [
-            '-cp', path.join(haxelibDir, 'src'),
-            '--run', 'tools.haxelib.Main'
+            '-cp', haxelibSrcDir,
+            '--run', haxelibMain
         ]
     },
     env : {


### PR DESCRIPTION
Basically there was old code referring to a `parent()` function that no longer exists (presumably refactored some time ago?), but it was never noticed because it was caught in a try/catch block, and JS has no type safety.

I've used the same code from above which detects the Haxe version.

I also changed the Haxe version detection code to look for `packageConfig('haxe')` instead of `packageConfig('version')` as the code seemed to be contradicting itself, and the README.

Fixes https://github.com/HaxeFoundation/npm-haxe/issues/11

Might also be helpful for https://github.com/HaxeFoundation/npm-haxe/issues/10