### PR TITLE
Fix 'haxelib_version' configuration

### DIFF
--- a/install.js
+++ b/install.js
@@ -75,7 +75,10 @@ if(haxeVersion == undefined){
 var nightly = packageConfig('nightly');
 var haxelibVersion = packageConfig('haxelib_version');
 try {
-	haxelibVersion = parent().parse().config.haxelib;
+	var pack = findPackageJson();
+	if(pack != false) {
+		haxelibVersion = pack.parse().config.haxelib_version;
+	}
 } catch (error){
 	console.warn('using default haxelib version');
 }


### PR DESCRIPTION
This should fix the 'haxelib_version' configuration value.

Why is this called "haxelib_version" instead of "haxelib", by the way?

Would it be possible to use haxelib 3.3.0? Is there more than classpaths that changed?