### PR TITLE
Fix broken readme highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This will also make the haxelib repo global.
 
 ### Package.json sample
 
-```json
+```js
 {
   "scripts":{
     "postinstall": "haxelib --always install build.hxml",


### PR DESCRIPTION
Using js instead of json highlighting fixes the comments looking like this:

![](https://i.imgur.com/pKUHq6r.png)