### PR TITLE
Use Neko to execute haxelib

### DIFF
--- a/lib/vars.js
+++ b/lib/vars.js
@@ -17,10 +17,9 @@ var vars = module.exports = {
         },
     haxelib : {
         dir: haxelibDir,
-        path: path.join(haxeDir, 'haxe'),
+        path: path.join(nekoDir, 'neko'),
         args: [
-            '-cp', path.join(haxelibDir, 'src'),
-            '--run', 'tools.haxelib.Main'
+            path.join(haxelibDir, 'run.n')
         ]
     },
     env : {


### PR DESCRIPTION
The previous command didn't work for me, but using Neko (now that it's included) seems to work great. This is necessary to include the recommend `postinstall` script, otherwise the install fails