### PR TITLE
Use https to download haxe archive

### DIFF
--- a/lib/haxe-url.js
+++ b/lib/haxe-url.js
@@ -31,7 +31,7 @@ module.exports = function ( platform, arch, majorVersion, nightly ) {
             url += '/haxe_'+nightly+'.tar.gz';
             break;
         default: 
-            url = 'http://haxe.org/website-content/downloads/' + version + '/downloads/haxe-' + version + '-';
+            url = 'https://haxe.org/website-content/downloads/' + version + '/downloads/haxe-' + version + '-';
             switch ( platform ) {
                 case 'linux': 
                     url += 'linux';


### PR DESCRIPTION
haxe downloads zipped resources over HTTP, which leaves it vulnerable to MITM attacks. It may be possible to cause remote code execution (RCE) by swapping out the requested zip file with an attacker controlled zip file if the attacker is on the network or positioned in between the user and the remote server.