### PR TITLE
Changed order of merging env vars

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -7,6 +7,5 @@ function merge( base , obj ) {
     }
 }
 
-merge( env, process.env );
 merge( env, vars.env );
-
+merge( env, process.env );


### PR DESCRIPTION
This allows them to be overwritten, right now they always point to the same path's. I'd like to be able to change them