### PR TITLE
update stdout and add git support for haxeDependencies

### DIFF
--- a/lib/install-haxelib-dependencies-task.js
+++ b/lib/install-haxelib-dependencies-task.js
@@ -8,27 +8,27 @@ var InstallHaxelibDependenciesTask = function (deps) {
 InstallHaxelibDependenciesTask.prototype.run = function(executeNextStep) {
     console.log("Installing Haxelib Dependencies" );
     var options = {
-            cwd : process.env.INIT_CWD
+            cwd : process.env.INIT_CWD,
+            stdio: [process.stdin, process.stdout, process.stderr],
+            encoding: 'utf-8'
         }
 
     for(var module in this.dependencies ){
         if(module != "haxe" && module != "haxelib" && module != "neko"){
             var version = this.dependencies[module];
-            console.log("version - " + version);
             if (version !== undefined && version.indexOf("git+") == 0){
-                console.log("git - " + module + ":" + version);
                 var gitRepo = version.substring(4, version.length);
                 console.log(module + ":" + gitRepo);
 
                 var r = proc.spawnSync("haxelib", ["git",module,gitRepo], options);
-                if(r.stdout != null) {console.log(r.stdout.toString());};
-                if(r.stderr != null){console.log(r.stderr.toString());}
+                //if(r.stdout != null) {console.log(r.stdout.toString());};
+                //if(r.stderr != null){console.log(r.stderr.toString());}
                 
             } else {   
                 console.log("install - " + module + ":" + version);
                 var r = proc.spawnSync("haxelib", ["install",module,version], options);
-                if(r.stdout != null) {console.log(r.stdout.toString());};
-                if(r.stderr != null){console.log(r.stderr.toString());}
+                //if(r.stdout != null) {console.log(r.stdout.toString());};
+                //if(r.stderr != null){console.log(r.stderr.toString());}
             }
             
 

--- a/lib/install-haxelib-dependencies-task.js
+++ b/lib/install-haxelib-dependencies-task.js
@@ -18,8 +18,8 @@ InstallHaxelibDependenciesTask.prototype.run = function(executeNextStep) {
             var version = this.dependencies[module];
             if (version !== undefined && version.indexOf("git+") == 0){
                 var gitRepo = version.substring(4, version.length);
-                console.log(module + ":" + gitRepo);
-                var r = proc.spawnSync("haxelib", ["git",module,gitRepo], options);
+                console.log("1 " + module + ":" + gitRepo);
+                var r = proc.spawnSync("haxelib", ["git", module, gitRepo, "--never"], options);
                 
             } else {   
                 console.log("1 install - " + module + ":" + version);

--- a/lib/install-haxelib-dependencies-task.js
+++ b/lib/install-haxelib-dependencies-task.js
@@ -18,11 +18,11 @@ InstallHaxelibDependenciesTask.prototype.run = function(executeNextStep) {
             var version = this.dependencies[module];
             if (version !== undefined && version.indexOf("git+") == 0){
                 var gitRepo = version.substring(4, version.length);
-                console.log("1 " + module + ":" + gitRepo);
+                console.log(module + ":" + gitRepo);
                 var r = proc.spawnSync("haxelib", ["git", module, gitRepo, "--never"], options);
                 
             } else {   
-                console.log("1 install - " + module + ":" + version);
+                console.log(module + ":" + version);
                 var r = proc.spawnSync("haxelib", ["install", module, version, "--never"], options);
             }
         }

--- a/lib/install-haxelib-dependencies-task.js
+++ b/lib/install-haxelib-dependencies-task.js
@@ -13,10 +13,23 @@ InstallHaxelibDependenciesTask.prototype.run = function(executeNextStep) {
 
     for(var module in this.dependencies ){
         if(module != "haxe" && module != "haxelib" && module != "neko"){
-            console.log(module + ":" + this.dependencies[module]);
-            var r = proc.spawnSync("haxelib", ["install",module,this.dependencies[module]], options);
-	    if(r.stdout != null) {console.log(r.stdout.toString());};
-	    if(r.stderr != null){console.log(r.stderr.toString());}
+            var version = this.dependencies[module];
+            if (version !== undefined && version.indexOf("git+") == 0){
+                console.log(module + ":" + version);
+                var gitRepo = version.substring(4, module.length);
+                console.log(module + ":" + gitRepo);
+
+                var r = proc.spawnSync("haxelib", ["git",module,gitRepo], options);
+                if(r.stdout != null) {console.log(r.stdout.toString());};
+                if(r.stderr != null){console.log(r.stderr.toString());}
+                
+            } else {   
+                console.log(module + ":" + version);
+                var r = proc.spawnSync("haxelib", ["install",module,version], options);
+                if(r.stdout != null) {console.log(r.stdout.toString());};
+                if(r.stderr != null){console.log(r.stderr.toString());}
+            }
+            
 
         }
     }

--- a/lib/install-haxelib-dependencies-task.js
+++ b/lib/install-haxelib-dependencies-task.js
@@ -19,19 +19,12 @@ InstallHaxelibDependenciesTask.prototype.run = function(executeNextStep) {
             if (version !== undefined && version.indexOf("git+") == 0){
                 var gitRepo = version.substring(4, version.length);
                 console.log(module + ":" + gitRepo);
-
                 var r = proc.spawnSync("haxelib", ["git",module,gitRepo], options);
-                //if(r.stdout != null) {console.log(r.stdout.toString());};
-                //if(r.stderr != null){console.log(r.stderr.toString());}
                 
             } else {   
                 console.log("install - " + module + ":" + version);
                 var r = proc.spawnSync("haxelib", ["install",module,version], options);
-                //if(r.stdout != null) {console.log(r.stdout.toString());};
-                //if(r.stderr != null){console.log(r.stderr.toString());}
             }
-            
-
         }
     }
 };

--- a/lib/install-haxelib-dependencies-task.js
+++ b/lib/install-haxelib-dependencies-task.js
@@ -22,8 +22,8 @@ InstallHaxelibDependenciesTask.prototype.run = function(executeNextStep) {
                 var r = proc.spawnSync("haxelib", ["git",module,gitRepo], options);
                 
             } else {   
-                console.log("install - " + module + ":" + version);
-                var r = proc.spawnSync("haxelib", ["install",module,version], options);
+                console.log("1 install - " + module + ":" + version);
+                var r = proc.spawnSync("haxelib", ["install", module, version, "--never"], options);
             }
         }
     }

--- a/lib/install-haxelib-dependencies-task.js
+++ b/lib/install-haxelib-dependencies-task.js
@@ -17,7 +17,7 @@ InstallHaxelibDependenciesTask.prototype.run = function(executeNextStep) {
             console.log("version - " + version);
             if (version !== undefined && version.indexOf("git+") == 0){
                 console.log("git - " + module + ":" + version);
-                var gitRepo = version.substring(4, module.length);
+                var gitRepo = version.substring(4, version.length);
                 console.log(module + ":" + gitRepo);
 
                 var r = proc.spawnSync("haxelib", ["git",module,gitRepo], options);

--- a/lib/install-haxelib-dependencies-task.js
+++ b/lib/install-haxelib-dependencies-task.js
@@ -14,8 +14,9 @@ InstallHaxelibDependenciesTask.prototype.run = function(executeNextStep) {
     for(var module in this.dependencies ){
         if(module != "haxe" && module != "haxelib" && module != "neko"){
             var version = this.dependencies[module];
+            console.log("version - " + version);
             if (version !== undefined && version.indexOf("git+") == 0){
-                console.log(module + ":" + version);
+                console.log("git - " + module + ":" + version);
                 var gitRepo = version.substring(4, module.length);
                 console.log(module + ":" + gitRepo);
 
@@ -24,7 +25,7 @@ InstallHaxelibDependenciesTask.prototype.run = function(executeNextStep) {
                 if(r.stderr != null){console.log(r.stderr.toString());}
                 
             } else {   
-                console.log(module + ":" + version);
+                console.log("install - " + module + ":" + version);
                 var r = proc.spawnSync("haxelib", ["install",module,version], options);
                 if(r.stdout != null) {console.log(r.stdout.toString());};
                 if(r.stderr != null){console.log(r.stderr.toString());}


### PR DESCRIPTION
process.stdin, process.stdout and process.stderr have been added to the options object and removed from after spawnSync. This results in logs being printed as libs are being installed. This change is particularly helpful if you are installing a large lib, or a lib with a lot of sub dependencies (before this change it would appear that the install was stuck).

The other addition is a way to add a git haxeDependencies.
To do this simply replace the version number with: "git+" followed by the git clone uri
eg:
```
"haxeDependencies": {
    "haxe": "4.0.0-rc.3",
    "haxelib": "3.3.0",
    "neko": "2.2.0",
    "sbComponents": "git+git@github.com:peteshand/sbComponents.git"
}
```
