### PR TITLE
Neko win32 fallback

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -18,7 +18,7 @@ var getHash = function ( data ) {
 
 function Cache(){
 
-    this.download = function(url, targetFolder, callback){
+    this.download = function(url, targetFolder, callback, err){
         console.log(url);
         var hash = getHash(url);
         var ref = this;
@@ -26,16 +26,19 @@ function Cache(){
             console.log("using cached version");
             ref.extract(hash,targetFolder,callback);
         } else {
+            if (err === undefined){
+                err = (err) => {
+                    console.error(err + " : Unable to download or extract " + url);
+                    process.exit(9);
+                }
+            }
             console.log("Downloading...")
             Download(url,cacheFolder + '/' + hash,{ extract: true, strip: 1 })
             .then(() => {
                 console.log('done!');
                 ref.extract(hash,targetFolder,callback);
             })
-            .catch((err) => {
-                console.error(err + " : Unable to download or extract " + url);
-                process.exit(9);
-            });
+            .catch(err);
     	}
     }
 

--- a/lib/download-neko-task.js
+++ b/lib/download-neko-task.js
@@ -9,8 +9,9 @@ var DownloadNekoTask = function (version) {
 DownloadNekoTask.prototype.run = function(executeNextStep) {
     console.log("Getting NekoVM " + this.nekoVersion );
     var version = this.nekoVersion.split('.').join('-');
+    var osPlatform = os.platform()
     var plateform="";
-     switch ( os.platform() ) {
+    switch ( osPlatform ) {
         case 'linux':
             plateform = 'linux.tar.gz';
             if( os.arch() == 'x64' ) {
@@ -22,6 +23,7 @@ DownloadNekoTask.prototype.run = function(executeNextStep) {
             break;
         case 'win32':
             plateform = 'win.zip';
+            break;
         case 'win64':
             plateform = 'win64.zip';
             break;
@@ -31,7 +33,17 @@ DownloadNekoTask.prototype.run = function(executeNextStep) {
     }
     var url = "https://github.com/HaxeFoundation/neko/releases/download/v"+version+"/neko-"+this.nekoVersion+"-"+plateform;
     var cache = new Cache();
-    cache.download( url ,  vars.neko.dir, executeNextStep );
+    cache.download( url ,  vars.neko.dir, executeNextStep, (err) => {
+        if (osPlatform == 'win64'){
+            // fallback to win32
+            plateform = 'win.zip';
+            url = "https://github.com/HaxeFoundation/neko/releases/download/v"+version+"/neko-"+this.nekoVersion+"-"+plateform;
+            cache.download( url ,  vars.neko.dir, executeNextStep);
+        } else {
+            console.error(err + " : Unable to download or extract " + url);
+            process.exit(9);
+        }
+    } );
 };
 
 module.exports.DownloadNekoTask = DownloadNekoTask;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haxe",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "homepage": "http://haxe.org/",
   "description": "Wrapper of Haxe, an open source toolkit based on a modern, high level, strictly typed programming language, a cross-compiler, a complete cross-platform standard library and ways to access each platform's native capabilities.",
   "keywords": [

--- a/test/package.json
+++ b/test/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "gulp": "^4.0.0",
-    "haxe": "file:haxe-5.1.1.tgz"
+    "haxe": "file:haxe-5.1.2.tgz"
   },
   "haxeDependencies": {
     "haxe": "3.4.7",


### PR DESCRIPTION
I've been having issues getting npm-haxe to place nicely with Windows.
After a lot of debugging I've had to drop the neko version down to 2.1.0 for my project (which is the same version that is bundled with the haxe 4.0.0-rc3). However this results in an error while trying to download neko.

There were two issues.
The first was that there is a switch where the case 'win32' doesn't have a break, which results in the 'win64' version always being downloaded. This is now fixed.

The next issue is that there is no 'win64' version of neko 2.1.0, so the download fails.
I've added some 'win32' fallback logic.