### PR TITLE
Fix Dependency Version Env Var Overrides

### DIFF
--- a/install.js
+++ b/install.js
@@ -65,7 +65,7 @@ var pack = findPackageJson();
 function getHaxeDependencies(){
     var deps;
     
-	try {
+    try {
         deps = pack.parse().haxeDependencies;
     } catch (error){
       console.warn('no dependencies');

--- a/install.js
+++ b/install.js
@@ -76,7 +76,7 @@ function getHaxeDependencies(){
 
 function getVersion(module){
     var envVersion = packageConfig(module);
-	var packageVersion;
+    var packageVersion;
 
     try {
         packageVersion = getHaxeDependencies()[module];

--- a/install.js
+++ b/install.js
@@ -63,26 +63,30 @@ function findPackageJson() {
 var pack = findPackageJson();
 
 function getHaxeDependencies(){
-    var deps = [];
-    try {
+    var deps;
+    
+	try {
         deps = pack.parse().haxeDependencies;
     } catch (error){
       console.warn('no dependencies');
     }
+
     return deps;
 }
 
 function getVersion(module){
-    var version = packageConfig(module);
+    var envVersion = packageConfig(module);
+	var packageVersion;
+
     try {
-        version = getHaxeDependencies()[module];
+        packageVersion = getHaxeDependencies()[module];
     } catch (error){
         console.warn('using default '+ module +' version');
     }
-    if(version == undefined){
-        version = localConfig.haxeDependencies[module];
-    }
-    return version;
+
+    var localFallbackVersion = localConfig.haxeDependencies[module];
+
+    return packageVersion || envVersion || localFallbackVersion;
 }
 
 var runner = new TaskRunner();


### PR DESCRIPTION
Found a bug in `getHaxeDependencies` that always resulted in env vars being ignored.