### PR TITLE
Add support for NODE_TLS_REJECT_UNAUTHORIZED

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -17,7 +17,6 @@ var getHash = function ( data ) {
 }
 
 function Cache(){
-
     this.download = function(url, targetFolder, callback, err){
         console.log(url);
         var hash = getHash(url);
@@ -26,19 +25,27 @@ function Cache(){
             console.log("using cached version");
             ref.extract(hash,targetFolder,callback);
         } else {
-            if (err === undefined){
+            if (err === undefined) {
                 err = (err) => {
                     console.error(err + " : Unable to download or extract " + url);
                     process.exit(9);
                 }
             }
-            console.log("Downloading...")
-            Download(url,cacheFolder + '/' + hash,{ extract: true, strip: 1 })
-            .then(() => {
-                console.log('done!');
-                ref.extract(hash,targetFolder,callback);
-            })
-            .catch(err);
+
+            console.log("Downloading...");
+            
+            var options = { 
+                extract: true, 
+                strip: 1, 
+                rejectUnauthorized: process.env["NODE_TLS_REJECT_UNAUTHORIZED"] === "0"
+            };
+
+            Download(url, cacheFolder + '/' + hash, options)
+                .then(() => {
+                    console.log('done!');
+                    ref.extract(hash,targetFolder,callback);
+                })
+                .catch(err);
     	}
     }
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -33,11 +33,7 @@ function Cache(){
             }
 
             var rejectUnauthorized = process.env["NODE_TLS_REJECT_UNAUTHORIZED"] !== "0";
-            if (rejectUnauthorized) {
-                console.log("Downloading insecurely...");
-            } else {
-                console.log("Downloading securely...");
-            }
+            console.log("Downloading...");
             
             var options = { 
                 extract: true, 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -32,12 +32,17 @@ function Cache(){
                 }
             }
 
-            console.log("Downloading...");
+            var rejectUnauthorized = process.env["NODE_TLS_REJECT_UNAUTHORIZED"] !== "0";
+            if (rejectUnauthorized) {
+                console.log("Downloading insecurely...");
+            } else {
+                console.log("Downloading securely...");
+            }
             
             var options = { 
                 extract: true, 
                 strip: 1, 
-                rejectUnauthorized: process.env["NODE_TLS_REJECT_UNAUTHORIZED"] === "0"
+                rejectUnauthorized: rejectUnauthorized
             };
 
             Download(url, cacheFolder + '/' + hash, options)


### PR DESCRIPTION
This change honours the NODE_TLS_REJECT_UNAUTHORIZED environment variable for downloads.

The Download lib used tries to honour this via the npm config here: https://github.com/kevva/download/blob/master/index.js#L68

However npm overwrites all of these environment variables when launching install scripts.